### PR TITLE
Make handy-decorators py2 and py3 compat

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Currently, the wheel is only built for python2, makes it impossible to pip install on any py3 setups