### PR TITLE
Add `typing` integration

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,46 +1,47 @@
 import pytest
+import typing
 
 class TestValgrindParser(object):
-    def test_trycatch_decorator(self):
+    def test_trycatch_decorator(self) -> None:
         from src.decorators import trycatch
         @trycatch
-        def func():
-            a = []
+        def func() -> object:
+            a: list[object] = []
             return a[2]  # Index error
 
         func()
 
-    def test_timer_decorator(self):
+    def test_timer_decorator(self) -> None:
         from src.decorators import timer
         @timer
-        def func():
+        def func() -> None:
             pass
 
         func()
 
-    def test_singleton_decorator(self):
+    def test_singleton_decorator(self) -> None:
         from src.decorators import singleton
         @singleton
         class A(object):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 pass
 
-        obj1 = A(name='Siddhesh')
-        obj2 = A(name='Siddhesh', lname='Sathe')
-        obj3 = A(name='Siddhesh', lname='Sathe')
+        obj1: A = A(name='Siddhesh')
+        obj2: A = A(name='Siddhesh', lname='Sathe')
+        obj3: A = A(name='Siddhesh', lname='Sathe')
         assert obj1 is not obj2, "Created objects must be different"
         assert obj2 is obj3, "Created objects must be same"
 
-    def test_run_in_thread(self):
+    def test_run_in_thread(self) -> None:
         from src.decorators import run_in_thread
         @run_in_thread
-        def display(*args, **kwargs):
+        def display(*args, **kwargs) -> None:
             pass
         display()
 
-    def test_create_n_thread(self):
+    def test_create_n_thread(self) -> None:
         from src.decorators import create_n_threads
         @create_n_threads(thread_count=2)
-        def display(*args, **kwargs):
+        def display(*args, **kwargs) -> None:
             pass
         display()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,47 +1,76 @@
+import io
+import re
 import pytest
 import typing
+import logging
+import contextlib
+
 
 class TestValgrindParser(object):
-    def test_trycatch_decorator(self) -> None:
+    def test_trycatch_decorator(self, caplog: pytest.LogCaptureFixture) -> None:
         from src.decorators import trycatch
+
         @trycatch
         def func() -> object:
             a: list[object] = []
             return a[2]  # Index error
 
-        func()
+        with caplog.at_level(logging.INFO):
+            result = func()
 
-    def test_timer_decorator(self) -> None:
+        assert len(caplog.records) == 1, "A single message must be logged"
+        record = caplog.records[0]
+        assert (
+            record.message == "Exception occurred: [list index out of range]"
+        ), "A message with the error must be logged"
+        assert result is None, "The returned value must be None if there's error"
+
+    def test_timer_decorator(self, caplog: pytest.LogCaptureFixture) -> None:
         from src.decorators import timer
-        @timer
-        def func() -> None:
-            pass
 
-        func()
+        @timer
+        def func() -> int:
+            return 42
+
+        with caplog.at_level(logging.INFO):
+            result = func()
+
+        pattern = re.compile(r"Time taken by the function is \[\d+\.\d+\] sec")
+        assert len(caplog.records) == 1, "A single message must be logged"
+        record = caplog.records[0]
+        assert pattern.match(
+            record.message
+        ), "A message with the time taken must be logged"
+        assert result == 42, "The returned value must be not None if it's the case"
 
     def test_singleton_decorator(self) -> None:
         from src.decorators import singleton
+
         @singleton
         class A(object):
             def __init__(self, *args, **kwargs) -> None:
                 pass
 
-        obj1: A = A(name='Siddhesh')
-        obj2: A = A(name='Siddhesh', lname='Sathe')
-        obj3: A = A(name='Siddhesh', lname='Sathe')
+        obj1: A = A(name="Siddhesh")
+        obj2: A = A(name="Siddhesh", lname="Sathe")
+        obj3: A = A(name="Siddhesh", lname="Sathe")
         assert obj1 is not obj2, "Created objects must be different"
         assert obj2 is obj3, "Created objects must be same"
 
     def test_run_in_thread(self) -> None:
         from src.decorators import run_in_thread
+
         @run_in_thread
         def display(*args, **kwargs) -> None:
             pass
+
         display()
 
     def test_create_n_thread(self) -> None:
         from src.decorators import create_n_threads
+
         @create_n_threads(thread_count=2)
         def display(*args, **kwargs) -> None:
             pass
+
         display()


### PR DESCRIPTION
This PR adds integration with the `typing` module, specifically the specifications proposed by [PEP 612](https://peps.python.org/pep-0612/). 

This PR also makes some decorators to return the value returned by the wrapped function (such as `trycatch` and `timer`), so you can use them such as

```python
import decorators

@decorators.timer
def calculate(foo: int) -> int:
    return foo + 42

print(calculate(21))    # Previous version: prints None
                        # Current version: prints 63
```

The code is checked by [`mypy`](https://pypi.org/project/mypy/) and is also formatted by [`black`](https://pypi.org/project/black/).
